### PR TITLE
feat: Vue Routerを導入し404ページ実装とルーティング基盤を構築

### DIFF
--- a/my-portfolio/package-lock.json
+++ b/my-portfolio/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "pinia": "^3.0.4",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
@@ -2437,6 +2438,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "2.2.12",

--- a/my-portfolio/package.json
+++ b/my-portfolio/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "pinia": "^3.0.4",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/my-portfolio/src/App.vue
+++ b/my-portfolio/src/App.vue
@@ -1,21 +1,9 @@
 <template>
   <div class="min-h-screen w-full flex flex-col bg-black text-white">
     <AppHeader />
-      <main class="flex-1">
-        <HeroSection />
-        <ScrollReveal>
-          <SkillsSection />
-        </ScrollReveal>
-        <ScrollReveal>
-          <AboutSection />
-        </ScrollReveal>
-        <ScrollReveal>
-          <WorksSection />
-        </ScrollReveal>
-        <ScrollReveal>
-          <ContactSection />
-        </ScrollReveal>
-      </main>
+    <main class="flex-1">
+      <router-view />
+    </main>
     <AppFooter />
   </div>
 </template>
@@ -23,12 +11,6 @@
 <script setup lang="ts">
 import AppHeader from './components/common/AppHeader.vue';
 import AppFooter from './components/common/AppFooter.vue';
-import HeroSection from './components/sections/HeroSection.vue';
-import AboutSection from './components/sections/About/AboutSection.vue';
-import SkillsSection from './components/sections/Skills/SkillsSection.vue';
-import WorksSection from './components/sections/Works/WorkSection.vue';
-import ContactSection from './components/sections/Contact/ContactSection.vue';
-import ScrollReveal from './components/common/ScrollReveal.vue';
 import { onMounted } from 'vue';
 import { useThemeStore } from './stores/theme';
 
@@ -36,9 +18,4 @@ const theme = useThemeStore();
 onMounted(() => {
   theme.initTheme();
 })
-
 </script>
-
-<style scoped>
-/* CSS */
-</style>

--- a/my-portfolio/src/main.ts
+++ b/my-portfolio/src/main.ts
@@ -1,12 +1,12 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
+import router from './router'
 import './style.css'
 import './assets/global.css'
 import './assets/tailwind.css'
 
 const app = createApp(App)
-const pinia = createPinia()
-
-app.use(pinia)
+app.use(createPinia())
+app.use(router)
 app.mount('#app')

--- a/my-portfolio/src/router/index.ts
+++ b/my-portfolio/src/router/index.ts
@@ -1,0 +1,26 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+
+const router = createRouter({
+  // ブラウザの履歴モードを使用
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: HomeView
+    },
+    {
+      path: '/:pathMatch(.*)*', // どのURLにも当てはまらない場合の設定
+      name: 'not-found',
+      // 遅延ロード（必要な時だけ読み込む）にすることでパフォーマンスを向上
+      component: () => import('../views/NotFoundView.vue')
+    }
+  ],
+  // ページ遷移時に一番上までスクロールさせる設定
+  scrollBehavior() {
+    return { top: 0 }
+  }
+})
+
+export default router

--- a/my-portfolio/src/views/HomeView.vue
+++ b/my-portfolio/src/views/HomeView.vue
@@ -1,0 +1,24 @@
+<template>
+  <HeroSection />
+  <ScrollReveal>
+    <SkillsSection />
+  </ScrollReveal>
+  <ScrollReveal>
+    <AboutSection />
+  </ScrollReveal>
+  <ScrollReveal>
+    <WorksSection />
+  </ScrollReveal>
+  <ScrollReveal>
+    <ContactSection />
+  </ScrollReveal>
+</template>
+
+<script setup lang="ts">
+import HeroSection from '../components/sections/HeroSection.vue';
+import AboutSection from '../components/sections/About/AboutSection.vue';
+import SkillsSection from '../components/sections/Skills/SkillsSection.vue';
+import WorksSection from '../components/sections/Works/WorkSection.vue';
+import ContactSection from '../components/sections/Contact/ContactSection.vue';
+import ScrollReveal from '../components/common/ScrollReveal.vue';
+</script>

--- a/my-portfolio/src/views/NotFoundView.vue
+++ b/my-portfolio/src/views/NotFoundView.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="min-h-screen flex flex-col items-center justify-center bg-black text-white px-4">
+    <h1 class="text-9xl font-bold tracking-tighter text-white/20">404</h1>
+    <p class="text-xl mt-4 mb-8 text-gray-400">お探しのページは見つかりませんでした。</p>
+    <router-link
+      to="/"
+      class="px-8 py-3 bg-white text-black font-bold rounded-full hover:bg-gray-200 transition-all"
+    >
+      ホームに戻る
+    </router-link>
+  </div>
+</template>


### PR DESCRIPTION
[概要]
アプリ全体にVue Routerを導入し、コンテンツをView単位で管理する構造へリファクタリングしました。
これにより、存在しないURLへのアクセスに対する404エラーハンドリングが可能になりました。

[変更詳細]
- vue-router (v4) のインストールと初期設定 (src/router/index.ts)
- App.vue のメインコンテンツを src/views/HomeView.vue へ分離
- 未定義のパスをすべてキャッチする NotFoundView.vue を新規作成
- ページ遷移時のスクロール挙動（scrollBehavior）をトップ固定に設定
- main.ts へのルーターインスタンスの登録

[影響範囲]
- 全体のルーティング（トップページ、404ページ）
- App.vue の構造（Header/Footerを共通化し、中身をRouterViewで切り替え）